### PR TITLE
make frontend optional, fix pnpm not using latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ include .env
 
 all: up 
 
-up: .env backend/node_modules frontend/node_modules
-	docker compose up
+up: .env backend/node_modules
+	docker compose up --build
 
 down:
 	docker compose down

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:lts-alpine
 
-RUN npm i -g pnpm
+# https://pnpm.io/installation#using-corepack
+RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - internal
 
   frontend:
+    profiles: ["frontend"] # https://docs.docker.com/compose/profiles/
     build: ./frontend
     ports:
       - 3000:3000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:lts-alpine
 
-RUN npm i -g pnpm
+# https://pnpm.io/installation#using-corepack
+RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /frontend
 


### PR DESCRIPTION
# problema que essa PR resolve
Roda o projeto, e muda algo no front (ex, muda o texto do hello world) 
Resultado: não atualiza 🙃

# solução

O `make` agora por padrão sobre o `db` e o `backend`

- Da pra entrar no frontend, rodar `pnpm dev` que fica muito mais rápido, com live reload etc 

Ainda dá pra rodar como estava antes (com db, back, e front) ativando o perfil frontend 
```sh
docker compose --profile frontend up
```

Baseado na docs ->  https://docs.docker.com/compose/profiles/ 